### PR TITLE
fix: improve regex matching for dependabot PRs

### DIFF
--- a/ci-check.yml
+++ b/ci-check.yml
@@ -19,7 +19,7 @@ jobs:
         uses: morrisoncole/pr-lint-action@v1.7.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          title-regex: '^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|build(deps))(\([a-z\-]+\))?!?: .{1,72}$'
+          title-regex: '^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\([a-z\-]+\))?!?: .{1,72}$'
           on-failed-regex-fail-action: true
           on-failed-regex-request-changes: true
           on-failed-regex-comment: |

--- a/ci-check.yml
+++ b/ci-check.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Check branch naming rules
         uses: deepakputhraya/action-branch-name@master
         with:
-          regex: '^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|dependabot)\/[a-z0-9\/]+(-[a-z0-9]+)*$'
+          regex: '^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|dependabot)\/[a-z0-9-_\/]+?$'
           ignore: production,staging,dev
           min_length: 5
           max_length: 50
@@ -19,7 +19,7 @@ jobs:
         uses: morrisoncole/pr-lint-action@v1.7.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          title-regex: '^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\([a-z\-]+\))?!?: .{1,72}$'
+          title-regex: '^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|build(deps))(\([a-z\-]+\))?!?: .{1,72}$'
           on-failed-regex-fail-action: true
           on-failed-regex-request-changes: true
           on-failed-regex-comment: |


### PR DESCRIPTION
This PR improves the branch matching rule to catch cases like `dependabot/npm_and_yarn/aws-sdk-2.1374.0`