### PR TITLE
fix: add autoupdate branch to ignore list

### DIFF
--- a/ci-check.yml
+++ b/ci-check.yml
@@ -12,7 +12,7 @@ jobs:
         uses: deepakputhraya/action-branch-name@master
         with:
           regex: '^(build|chore|ci|docs|feat|fix|perf|refactor|release|revert|style|test|dependabot)\/[a-z0-9-_.\/]+?$'
-          ignore: production,staging,dev
+          ignore: production,staging,dev,dev-updated
           min_length: 5
           max_length: 100
       - name: Lint pull request title


### PR DESCRIPTION
This will bypass the branch naming rules for dev-updated branches.

Later we could open a PR on https://github.com/kawax/composer-update-action to enable conventional branch naming