### PR TITLE
fix: scope regex matcher

### DIFF
--- a/ci-check.yml
+++ b/ci-check.yml
@@ -19,7 +19,7 @@ jobs:
         uses: morrisoncole/pr-lint-action@v1.7.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          title-regex: '^(build|chore|ci|docs|feat|fix|perf|refactor|release|revert|style|test)(\([a-z\-]+\))?!?: .{1,140}$'
+          title-regex: '^(build|chore|ci|docs|feat|fix|perf|refactor|release|revert|style|test)\((.*?)\)!?: .{1,140}$'
           on-failed-regex-fail-action: true
           on-failed-regex-request-changes: true
           on-failed-regex-comment: |


### PR DESCRIPTION
This PR will accept any string in the scope of the conventional commit title like:

chore(l10n): update languages/pressbooks.pot
feat(anything): some useful message