### PR TITLE
fix: remove branch name requirement

### DIFF
--- a/ci-check.yml
+++ b/ci-check.yml
@@ -1,4 +1,4 @@
-name: Lint pull request title and branch name
+name: Lint pull request title
 
 on:
   pull_request:
@@ -8,13 +8,6 @@ jobs:
   branch-naming-rules:
     runs-on: ubuntu-latest
     steps:
-      - name: Check branch naming rules
-        uses: deepakputhraya/action-branch-name@master
-        with:
-          regex: '^(build|chore|ci|docs|feat|fix|perf|refactor|release|revert|style|test|dependabot)\/[a-z0-9-_.\/]+?$'
-          ignore: production,staging,dev,dev-updated,staging-updated
-          min_length: 5
-          max_length: 100
       - name: Lint pull request title
         uses: morrisoncole/pr-lint-action@v1.7.0
         with:


### PR DESCRIPTION
Remove the branch name requirement. We will continue to use branch naming conventions internally, but this is not a requirement for merging PRs. This will help us with PRs opened by release-please and our bedrock updater action.