### PR TITLE
fix: not trigger pot update on release PRs

### DIFF
--- a/.github/workflows/update-pot.yml
+++ b/.github/workflows/update-pot.yml
@@ -49,9 +49,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.PAT_FOR_GITHUB_ACTIONS }}
 
-      - name: Debug labels
-        run: echo "${{ steps.get_pr_labels.outputs.labels }}"
-
       - name: Set up PHP
         if: contains(steps.get_pr_labels.outputs.labels, 'autorelease') == false
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/update-pot.yml
+++ b/.github/workflows/update-pot.yml
@@ -53,24 +53,24 @@ jobs:
         run: echo "${{ steps.get_pr_labels.outputs.labels }}"
 
       - name: Set up PHP
-        if: contains(steps.get_pr_labels.outputs.labels, 'autorelease')
+        if: contains(steps.get_pr_labels.outputs.labels, 'autorelease') == false
         uses: shivammathur/setup-php@v2
         with:
           php-version: '8.1'
           tools: wp-cli/wp-cli-bundle
 
       - name: Update POT file
-        if: contains(steps.get_pr_labels.outputs.labels, 'autorelease')
+        if: contains(steps.get_pr_labels.outputs.labels, 'autorelease') == false
         run: wp i18n make-pot . languages/${{ github.event.repository.name }}.pot --domain=${{ inputs.domain }} --slug=${{ inputs.slug }} --package-name="${{ inputs.package_name }}" --headers='${{ inputs.headers }}'
 
       - name: Configure Git
-        if: contains(steps.get_pr_labels.outputs.labels, 'autorelease')
+        if: contains(steps.get_pr_labels.outputs.labels, 'autorelease') == false
         run: |
           git config --global user.email "actions@github.com"
           git config --global user.name "GitHub Actions"
 
       - name: Commit and push .pot file
-        if: contains(steps.get_pr_labels.outputs.labels, 'autorelease')
+        if: contains(steps.get_pr_labels.outputs.labels, 'autorelease') == false
         run: |
           git checkout ${{ github.head_ref }}
           git add languages/${{ github.event.repository.name }}.pot

--- a/.github/workflows/update-pot.yml
+++ b/.github/workflows/update-pot.yml
@@ -38,11 +38,7 @@ jobs:
         uses: actions/github-script@v6
         with:
           script: |
-            const { getOctokit, context } = require('@actions/github');
-            const core = require('@actions/core');
-            const token = core.getInput('GITHUB_TOKEN');
-            const octokit = getOctokit(token);
-            const pr = await octokit.pulls.get({
+            const pr = await github.rest.pulls.get({
               owner: context.repo.owner,
               repo: context.repo.repo,
               pull_number: ${{ inputs.pull_request_number }}
@@ -50,7 +46,7 @@ jobs:
             const labels = pr.data.labels.map(label => label.name).join(',');
             core.setOutput('labels', labels);
         env:
-          GITHUB_TOKEN: ${{ secrets.PAT_FOR_GITHUB_ACTIONS }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check if PR is a release PR
         id: skip_if_autorelease

--- a/.github/workflows/update-pot.yml
+++ b/.github/workflows/update-pot.yml
@@ -38,13 +38,19 @@ jobs:
         uses: actions/github-script@v6
         with:
           script: |
-            const pr = await github.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
+            const github = require('@actions/github');
+            const core = require('@actions/core');
+            const token = core.getInput('github-token');
+            const octokit = github.getOctokit(token);
+            const pr = await octokit.pulls.get({
+              owner: github.context.repo.owner,
+              repo: github.context.repo.repo,
               pull_number: ${{ inputs.pull_request_number }}
             });
             const labels = pr.data.labels.map(label => label.name).join(',');
             core.setOutput('labels', labels);
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check if PR is a release PR
         id: skip_if_autorelease

--- a/.github/workflows/update-pot.yml
+++ b/.github/workflows/update-pot.yml
@@ -50,7 +50,7 @@ jobs:
             const labels = pr.data.labels.map(label => label.name).join(',');
             core.setOutput('labels', labels);
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PAT_FOR_GITHUB_ACTIONS }}
 
       - name: Check if PR is a release PR
         id: skip_if_autorelease

--- a/.github/workflows/update-pot.yml
+++ b/.github/workflows/update-pot.yml
@@ -19,6 +19,10 @@ on:
         type: string
         description: 'Additional headers in JSON format'
         required: true
+      pull_request_number:
+        type: number
+        description: 'Pull request number'
+        required: true
 
 jobs:
   update-pot:
@@ -37,7 +41,7 @@ jobs:
             const pr = await github.pulls.get({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              pull_number: context.payload.pull_request.number
+              pull_number: ${{ inputs.pull_request_number }}
             });
             const labels = pr.data.labels.map(label => label.name).join(',');
             core.setOutput('labels', labels);

--- a/.github/workflows/update-pot.yml
+++ b/.github/workflows/update-pot.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Get pull request labels
         id: get_pr_labels
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             const pr = await github.rest.pulls.get({
@@ -47,7 +47,10 @@ jobs:
             console.log('Pull request labels:', labels);
             core.setOutput('labels', labels);
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PAT_FOR_GITHUB_ACTIONS }}
+
+      - name: Debug labels
+        run: echo "${{ steps.get_pr_labels.outputs.labels }}"
 
       - name: Set up PHP
         if: contains(steps.get_pr_labels.outputs.labels, 'autorelease')

--- a/.github/workflows/update-pot.yml
+++ b/.github/workflows/update-pot.yml
@@ -38,13 +38,13 @@ jobs:
         uses: actions/github-script@v6
         with:
           script: |
-            const github = require('@actions/github');
+            const { getOctokit, context } = require('@actions/github');
             const core = require('@actions/core');
-            const token = core.getInput('github-token');
-            const octokit = github.getOctokit(token);
+            const token = core.getInput('GITHUB_TOKEN');
+            const octokit = getOctokit(token);
             const pr = await octokit.pulls.get({
-              owner: github.context.repo.owner,
-              repo: github.context.repo.repo,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
               pull_number: ${{ inputs.pull_request_number }}
             });
             const labels = pr.data.labels.map(label => label.name).join(',');

--- a/.github/workflows/update-pot.yml
+++ b/.github/workflows/update-pot.yml
@@ -27,26 +27,50 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref }}
           fetch-depth: 0
 
+      - name: Get pull request labels
+        id: get_pr_labels
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const pr = await github.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number
+            });
+            const labels = pr.data.labels.map(label => label.name).join(',');
+            core.setOutput('labels', labels);
+
+      - name: Check if PR is a release PR
+        id: skip_if_autorelease
+        run: |
+          if [[ "${{ steps.get_pr_labels.outputs.labels }}" == *"autorelease: pending"* ]]; then
+            echo "This PR has an 'autorelease: pending' label. Skipping the workflow.";
+            exit 0;
+          fi
+
       - name: Set up PHP
+        if: ${{ steps.skip_if_autorelease.conclusion != 'success' }}
         uses: shivammathur/setup-php@v2
         with:
           php-version: '8.1'
           tools: wp-cli/wp-cli-bundle
 
       - name: Update POT file
+        if: ${{ steps.skip_if_autorelease.conclusion != 'success' }}
         run: wp i18n make-pot . languages/${{ github.event.repository.name }}.pot --domain=${{ inputs.domain }} --slug=${{ inputs.slug }} --package-name="${{ inputs.package_name }}" --headers='${{ inputs.headers }}'
 
       - name: Configure Git
+        if: ${{ steps.skip_if_autorelease.conclusion != 'success' }}
         run: |
           git config --global user.email "actions@github.com"
           git config --global user.name "GitHub Actions"
 
       - name: Commit and push .pot file
+        if: ${{ steps.skip_if_autorelease.conclusion != 'success' }}
         run: |
           git checkout ${{ github.head_ref }}
-          git add -A
+          git add languages/${{ github.event.repository.name }}.pot
           git commit -m "chore(l10n): update pot file"
           git push origin ${{ github.head_ref }}

--- a/.github/workflows/update-pot.yml
+++ b/.github/workflows/update-pot.yml
@@ -46,7 +46,7 @@ jobs:
             const labels = pr.data.labels.map(label => label.name).join(',');
             core.setOutput('labels', labels);
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PAT_FOR_GITHUB_ACTIONS }}
 
       - name: Check if PR is a release PR
         id: skip_if_autorelease

--- a/.github/workflows/update-pot.yml
+++ b/.github/workflows/update-pot.yml
@@ -44,37 +44,30 @@ jobs:
               pull_number: ${{ inputs.pull_request_number }}
             });
             const labels = pr.data.labels.map(label => label.name).join(',');
+            console.log('Pull request labels:', labels);
             core.setOutput('labels', labels);
         env:
-          GITHUB_TOKEN: ${{ secrets.PAT_FOR_GITHUB_ACTIONS }}
-
-      - name: Check if PR is a release PR
-        id: skip_if_autorelease
-        run: |
-          if [[ "${{ steps.get_pr_labels.outputs.labels }}" == *"autorelease: pending"* ]]; then
-            echo "This PR has an 'autorelease: pending' label. Skipping the workflow.";
-            exit 0;
-          fi
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up PHP
-        if: ${{ steps.skip_if_autorelease.conclusion != 'success' }}
+        if: contains(steps.get_pr_labels.outputs.labels, 'autorelease')
         uses: shivammathur/setup-php@v2
         with:
           php-version: '8.1'
           tools: wp-cli/wp-cli-bundle
 
       - name: Update POT file
-        if: ${{ steps.skip_if_autorelease.conclusion != 'success' }}
+        if: contains(steps.get_pr_labels.outputs.labels, 'autorelease')
         run: wp i18n make-pot . languages/${{ github.event.repository.name }}.pot --domain=${{ inputs.domain }} --slug=${{ inputs.slug }} --package-name="${{ inputs.package_name }}" --headers='${{ inputs.headers }}'
 
       - name: Configure Git
-        if: ${{ steps.skip_if_autorelease.conclusion != 'success' }}
+        if: contains(steps.get_pr_labels.outputs.labels, 'autorelease')
         run: |
           git config --global user.email "actions@github.com"
           git config --global user.name "GitHub Actions"
 
       - name: Commit and push .pot file
-        if: ${{ steps.skip_if_autorelease.conclusion != 'success' }}
+        if: contains(steps.get_pr_labels.outputs.labels, 'autorelease')
         run: |
           git checkout ${{ github.head_ref }}
           git add languages/${{ github.event.repository.name }}.pot


### PR DESCRIPTION
We don't want to update the pot when release PRs are opened