### PR TITLE
chore: bump latest wp version

### DIFF
--- a/.github/workflows/pb-plugin-tests.yml
+++ b/.github/workflows/pb-plugin-tests.yml
@@ -32,11 +32,11 @@ jobs:
       fail-fast: false
       matrix:
         php: [ 8.1, 8.2 ]
-        wordpress: [ 6.6, latest ]
+        wordpress: [ 6.6.1, latest ]
         experimental: [ false ]
         include:
           - php: 8.2
-            wordpress: 6.6
+            wordpress: 6.6.1
             experimental: true
 
     name: Test - PHP ${{ matrix.php }} - WP ${{ matrix.wordpress }}


### PR DESCRIPTION
Armonize test suite with the latest supported version