### PR TITLE
chore: bump wp version

### DIFF
--- a/.github/workflows/pb-plugin-tests.yml
+++ b/.github/workflows/pb-plugin-tests.yml
@@ -32,11 +32,11 @@ jobs:
       fail-fast: false
       matrix:
         php: [ 8.1, 8.2 ]
-        wordpress: [ 6.6.1, latest ]
+        wordpress: [ 6.6.2, latest ]
         experimental: [ false ]
         include:
           - php: 8.2
-            wordpress: 6.6.1
+            wordpress: 6.6.2
             experimental: true
 
     name: Test - PHP ${{ matrix.php }} - WP ${{ matrix.wordpress }}


### PR DESCRIPTION
Just regular WP update

https://wordpress.org/documentation/wordpress-version/version-6-6-2/