### PR TITLE
chore: misc updates to improve performance

### DIFF
--- a/.github/workflows/pb-plugin-tests.yml
+++ b/.github/workflows/pb-plugin-tests.yml
@@ -25,17 +25,17 @@ on:
         default: true
 
 jobs:
-  mysql-tests:
-    if: "!inputs.use_mariadb"
+  tests:
     runs-on: ubuntu-20.04
+    
     services:
       database:
-        image: mysql:8.0
+        image: ${{ (inputs.use_mariadb) && 'mariadb:10.5' || 'mysql:8.0' }}
         env:
           MYSQL_ROOT_PASSWORD: root
         ports:
           - 3306:3306
-        options: --health-cmd="mysqladmin ping" --health-interval=5s --health-timeout=5s --health-retries=3
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
 
     strategy:
       fail-fast: false
@@ -51,108 +51,7 @@ jobs:
             wordpress: 6.7
             experimental: true
 
-    name: Matrix
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Setup PHP and extensions
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php }}
-          tools: composer
-          coverage: pcov
-          extensions: imagick
-
-      - name: Get Composer Cache Directory
-        id: composer-cache
-        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
-
-      - name: Cache Composer dependencies
-        uses: actions/cache@v4
-        with:
-          path: |
-            ${{ steps.composer-cache.outputs.dir }}
-            vendor
-          key: ${{ runner.os }}-composer-${{ matrix.php }}-${{ hashFiles('**/composer.json', '**/composer.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-composer-${{ matrix.php }}-
-            ${{ runner.os }}-composer-
-
-      - name: Cache WordPress test suite
-        uses: actions/cache@v4
-        with:
-          path: /tmp/wordpress-tests-lib
-          key: ${{ runner.os }}-wordpress-${{ matrix.wordpress }}-${{ hashFiles('bin/install-wp-tests.sh') }}
-
-      - name: Install PHP dependencies
-        env:
-          COMPOSER_AUTH: '{"github-oauth": {"github.com": "${{secrets.PAT_FOR_GITHUB_ACTIONS}}"} }'
-        run: |
-          export PATH="$HOME/.composer/vendor/bin:$PATH"
-          composer install --no-interaction --prefer-dist
-          echo "REPO_NAME=$(basename $(pwd))" >> $GITHUB_ENV
-
-      - name: Check Standards
-        run: composer standards
-
-      - name: Require Pressbooks
-        if: inputs.requires_pressbooks == true
-        run: |
-          git clone --depth=1 --single-branch https://github.com/pressbooks/pressbooks.git ../pressbooks
-          cd ../pressbooks && composer install --no-dev --prefer-dist
-          cd ../$REPO_NAME
-
-      - name: Require Private Repo
-        if: inputs.requires_private_repo != ''
-        run: |
-          git clone --depth=1 --single-branch https://x-access-token:${{secrets.PAT_FOR_GITHUB_ACTIONS}}@github.com/pressbooks/${{ inputs.requires_private_repo }}.git ../${{ inputs.requires_private_repo }}
-          cd ../${{ inputs.requires_private_repo }} && composer install --no-dev --prefer-dist
-          cd ../$REPO_NAME
-
-      - name: Install WP tests
-        run: bash bin/install-wp-tests.sh wordpress_test root root 127.0.0.1 ${{ matrix.wordpress }}
-
-      - name: Run PHP Tests
-        if: matrix.experimental == true
-        run: composer test
-
-      - name: Run PHP Tests and PCOV
-        if: matrix.experimental == false && inputs.code_coverage == true
-        run: composer test-coverage
-
-      - name: Upload Coverage to Codecov
-        if: matrix.experimental == false && inputs.code_coverage == true
-        run: bash <(curl -s https://codecov.io/bash)
-
-  mariadb-tests:
-    if: inputs.use_mariadb
-    runs-on: ubuntu-20.04
-    services:
-      database:
-        image: mariadb:10.5
-        env:
-          MYSQL_ROOT_PASSWORD: root
-        ports:
-          - 3306:3306
-        options: --health-cmd="mysqladmin ping" --health-interval=5s --health-timeout=5s --health-retries=3
-
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - php: 8.1
-            wordpress: 6.7
-            experimental: false
-          - php: 8.1
-            wordpress: latest
-            experimental: false
-          - php: 8.2
-            wordpress: 6.7
-            experimental: true
-
-    name: PHP MariaDB
+    name: PHP ${{ matrix.php }} - WP ${{ matrix.wordpress }} - ${{ inputs.use_mariadb && 'MariaDB' || 'MySQL' }}
 
     steps:
       - name: Checkout code

--- a/.github/workflows/pb-plugin-tests.yml
+++ b/.github/workflows/pb-plugin-tests.yml
@@ -51,7 +51,7 @@ jobs:
             wordpress: 6.7
             experimental: true
 
-    name: PHP MySQL
+    name: Matrix
 
     steps:
       - name: Checkout code

--- a/.github/workflows/pb-plugin-tests.yml
+++ b/.github/workflows/pb-plugin-tests.yml
@@ -46,12 +46,12 @@ jobs:
             experimental: false
           - php: 8.1
             wordpress: latest
-            experimental: false
+            experimental: true
           - php: 8.2
             wordpress: 6.7
             experimental: true
 
-    name: PHP ${{ matrix.php }} - WP ${{ matrix.wordpress }} - ${{ inputs.use_mariadb && 'MariaDB' || 'MySQL' }}
+    name: PHP ${{ matrix.php }} - WP ${{ matrix.wordpress }} - ${{ (inputs.use_mariadb) && 'MariaDB' || 'MySQL' }}
 
     steps:
       - name: Checkout code

--- a/.github/workflows/pb-plugin-tests.yml
+++ b/.github/workflows/pb-plugin-tests.yml
@@ -25,65 +25,134 @@ on:
         default: true
 
 jobs:
-  tests:
+  mysql-tests:
+    if: "!inputs.use_mariadb"
     runs-on: ubuntu-20.04
-    
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          # MySQL configurations
-          - php: 8.1
-            wordpress: 6.7
-            experimental: false
-            db_type: mysql
-            db_image: mysql:8.0
-            run_job: ${{ !inputs.use_mariadb }}
-          - php: 8.1
-            wordpress: latest
-            experimental: false
-            db_type: mysql
-            db_image: mysql:8.0
-            run_job: ${{ !inputs.use_mariadb }}
-          - php: 8.2
-            wordpress: 6.7
-            experimental: true
-            db_type: mysql
-            db_image: mysql:8.0
-            run_job: ${{ !inputs.use_mariadb }}
-          # MariaDB configurations
-          - php: 8.1
-            wordpress: 6.7
-            experimental: false
-            db_type: mariadb
-            db_image: mariadb:10.5
-            run_job: ${{ inputs.use_mariadb }}
-          - php: 8.1
-            wordpress: latest
-            experimental: false
-            db_type: mariadb
-            db_image: mariadb:10.5
-            run_job: ${{ inputs.use_mariadb }}
-          - php: 8.2
-            wordpress: 6.7
-            experimental: true
-            db_type: mariadb
-            db_image: mariadb:10.5
-            run_job: ${{ inputs.use_mariadb }}
-
-    name: PHP ${{ matrix.php }} - WP ${{ matrix.wordpress }} - ${{ matrix.db_type }}
-    
-    # Only run the job if run_job is true
-    if: ${{ matrix.run_job }}
-
     services:
       database:
-        image: ${{ matrix.db_image }}
+        image: mysql:8.0
         env:
           MYSQL_ROOT_PASSWORD: root
         ports:
           - 3306:3306
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - php: 8.1
+            wordpress: 6.7
+            experimental: false
+          - php: 8.1
+            wordpress: latest
+            experimental: false
+          - php: 8.2
+            wordpress: 6.7
+            experimental: true
+
+    name: PHP ${{ matrix.php }} - WP ${{ matrix.wordpress }} - MySQL
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP and extensions
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          tools: composer
+          coverage: pcov
+          extensions: imagick
+
+      - name: Get Composer Cache Directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ${{ steps.composer-cache.outputs.dir }}
+            vendor
+          key: ${{ runner.os }}-composer-${{ matrix.php }}-${{ hashFiles('**/composer.json', '**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-${{ matrix.php }}-
+            ${{ runner.os }}-composer-
+
+      - name: Cache WordPress test suite
+        uses: actions/cache@v4
+        with:
+          path: /tmp/wordpress-tests-lib
+          key: ${{ runner.os }}-wordpress-${{ matrix.wordpress }}-${{ hashFiles('bin/install-wp-tests.sh') }}
+
+      - name: Install PHP dependencies
+        env:
+          COMPOSER_AUTH: '{"github-oauth": {"github.com": "${{secrets.PAT_FOR_GITHUB_ACTIONS}}"} }'
+        run: |
+          export PATH="$HOME/.composer/vendor/bin:$PATH"
+          composer install --no-interaction --prefer-dist
+          echo "REPO_NAME=$(basename $(pwd))" >> $GITHUB_ENV
+
+      - name: Check Standards
+        run: composer standards
+
+      - name: Require Pressbooks
+        if: inputs.requires_pressbooks == true
+        run: |
+          git clone --depth=1 --single-branch https://github.com/pressbooks/pressbooks.git ../pressbooks
+          cd ../pressbooks && composer install --no-dev --prefer-dist
+          cd ../$REPO_NAME
+
+      - name: Require Private Repo
+        if: inputs.requires_private_repo != ''
+        run: |
+          git clone --depth=1 --single-branch https://x-access-token:${{secrets.PAT_FOR_GITHUB_ACTIONS}}@github.com/pressbooks/${{ inputs.requires_private_repo }}.git ../${{ inputs.requires_private_repo }}
+          cd ../${{ inputs.requires_private_repo }} && composer install --no-dev --prefer-dist
+          cd ../$REPO_NAME
+
+      - name: Install WP tests
+        run: bash bin/install-wp-tests.sh wordpress_test root root 127.0.0.1 ${{ matrix.wordpress }}
+
+      - name: Run PHP Tests
+        if: matrix.experimental == true
+        run: composer test
+
+      - name: Run PHP Tests and PCOV
+        if: matrix.experimental == false && inputs.code_coverage == true
+        run: composer test-coverage
+
+      - name: Upload Coverage to Codecov
+        if: matrix.experimental == false && inputs.code_coverage == true
+        run: bash <(curl -s https://codecov.io/bash)
+
+  mariadb-tests:
+    if: inputs.use_mariadb
+    runs-on: ubuntu-20.04
+    services:
+      database:
+        image: mariadb:10.5
+        env:
+          MYSQL_ROOT_PASSWORD: root
+        ports:
+          - 3306:3306
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - php: 8.1
+            wordpress: 6.7
+            experimental: false
+          - php: 8.1
+            wordpress: latest
+            experimental: false
+          - php: 8.2
+            wordpress: 6.7
+            experimental: true
+
+    name: PHP ${{ matrix.php }} - WP ${{ matrix.wordpress }} - MariaDB
 
     steps:
       - name: Checkout code

--- a/.github/workflows/pb-plugin-tests.yml
+++ b/.github/workflows/pb-plugin-tests.yml
@@ -51,7 +51,7 @@ jobs:
             wordpress: 6.7
             experimental: true
 
-    name: PHP ${{ matrix.php }} - WP ${{ matrix.wordpress }} - MySQL
+    name: PHP MySQL
 
     steps:
       - name: Checkout code
@@ -152,7 +152,7 @@ jobs:
             wordpress: 6.7
             experimental: true
 
-    name: PHP ${{ matrix.php }} - WP ${{ matrix.wordpress }} - MariaDB
+    name: PHP MariaDB
 
     steps:
       - name: Checkout code

--- a/.github/workflows/pb-plugin-tests.yml
+++ b/.github/workflows/pb-plugin-tests.yml
@@ -25,43 +25,69 @@ on:
         default: true
 
 jobs:
-  mysql-tests:
-    if: "!inputs.use_mariadb"
+  tests:
     runs-on: ubuntu-20.04
+    
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # MySQL configurations
+          - php: 8.1
+            wordpress: 6.7
+            experimental: false
+            db_type: mysql
+            db_image: mysql:8.0
+            run_job: ${{ !inputs.use_mariadb }}
+          - php: 8.1
+            wordpress: latest
+            experimental: false
+            db_type: mysql
+            db_image: mysql:8.0
+            run_job: ${{ !inputs.use_mariadb }}
+          - php: 8.2
+            wordpress: 6.7
+            experimental: true
+            db_type: mysql
+            db_image: mysql:8.0
+            run_job: ${{ !inputs.use_mariadb }}
+          # MariaDB configurations
+          - php: 8.1
+            wordpress: 6.7
+            experimental: false
+            db_type: mariadb
+            db_image: mariadb:10.5
+            run_job: ${{ inputs.use_mariadb }}
+          - php: 8.1
+            wordpress: latest
+            experimental: false
+            db_type: mariadb
+            db_image: mariadb:10.5
+            run_job: ${{ inputs.use_mariadb }}
+          - php: 8.2
+            wordpress: 6.7
+            experimental: true
+            db_type: mariadb
+            db_image: mariadb:10.5
+            run_job: ${{ inputs.use_mariadb }}
+
+    name: PHP ${{ matrix.php }} - WP ${{ matrix.wordpress }} - ${{ matrix.db_type }}
+    
+    # Only run the job if run_job is true
+    if: ${{ matrix.run_job }}
+
     services:
       database:
-        image: mysql:8.0
+        image: ${{ matrix.db_image }}
         env:
           MYSQL_ROOT_PASSWORD: root
         ports:
           - 3306:3306
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
 
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - php: 8.1
-            wordpress: 6.7
-            experimental: false
-          - php: 8.1
-            wordpress: latest
-            experimental: false
-          - php: 8.2
-            wordpress: 6.7
-            experimental: true
-
-    name: Tests 🔧
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-
-      - name: Cache Composer packages
-        uses: actions/cache@v4
-        with:
-          path: vendor
-          key: php-${{ matrix.php }}-composer-${{ hashFiles('**/composer.lock') }}
 
       - name: Setup PHP and extensions
         uses: shivammathur/setup-php@v2
@@ -71,98 +97,33 @@ jobs:
           coverage: pcov
           extensions: imagick
 
-      - name: Install PHP dependencies
-        env:
-          COMPOSER_AUTH: '{"github-oauth": {"github.com": "${{secrets.PAT_FOR_GITHUB_ACTIONS}}"} }'
-        run: |
-          export PATH="$HOME/.composer/vendor/bin:$PATH"
-          composer install --no-interaction
-          echo "REPO_NAME=$(basename $(pwd))" >> $GITHUB_ENV
+      - name: Get Composer Cache Directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
-      - name: Check Standards
-        run: composer standards
-
-      - name: Require Pressbooks
-        if: inputs.requires_pressbooks == true
-        run: |
-          git clone --depth=1 https://github.com/pressbooks/pressbooks.git ../pressbooks
-          cd ../pressbooks && composer install --no-dev
-          cd ../$REPO_NAME
-
-      - name: Require Private Repo
-        if: inputs.requires_private_repo != ''
-        run: |
-          git clone --depth=1 https://x-access-token:${{secrets.PAT_FOR_GITHUB_ACTIONS}}@github.com/pressbooks/${{ inputs.requires_private_repo }}.git ../${{ inputs.requires_private_repo }}
-          cd ../${{ inputs.requires_private_repo }} && composer install --no-dev
-          cd ../$REPO_NAME
-
-      - name: Install WP tests
-        run: bash bin/install-wp-tests.sh wordpress_test root root 127.0.0.1 ${{ matrix.wordpress }}
-
-      - name: Run PHP Tests
-        run: composer test
-        if: matrix.experimental == true
-
-      - name: Run PHP Tests and PCOV
-        run: composer test-coverage
-        if: matrix.experimental == false && inputs.code_coverage == true
-
-      - name: Upload Coverage to Codecov
-        run: bash <(curl -s https://codecov.io/bash)
-        if: matrix.experimental == false && inputs.code_coverage == true
-
-  mariadb-tests:
-    if: inputs.use_mariadb
-    runs-on: ubuntu-20.04
-    services:
-      database:
-        image: mariadb:10.5
-        env:
-          MYSQL_ROOT_PASSWORD: root
-        ports:
-          - 3306:3306
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
-
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - php: 8.1
-            wordpress: 6.7
-            experimental: false
-          - php: 8.1
-            wordpress: latest
-            experimental: false
-          - php: 8.2
-            wordpress: 6.7
-            experimental: true
-
-    name: Test - PHP ${{ matrix.php }} - WP ${{ matrix.wordpress }}
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Cache Composer packages
+      - name: Cache Composer dependencies
         uses: actions/cache@v4
         with:
-          path: vendor
-          key: php-${{ matrix.php }}-composer-${{ hashFiles('**/composer.lock') }}
+          path: |
+            ${{ steps.composer-cache.outputs.dir }}
+            vendor
+          key: ${{ runner.os }}-composer-${{ matrix.php }}-${{ hashFiles('**/composer.json', '**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-${{ matrix.php }}-
+            ${{ runner.os }}-composer-
 
-      - name: Setup PHP and extensions
-        uses: shivammathur/setup-php@v2
+      - name: Cache WordPress test suite
+        uses: actions/cache@v4
         with:
-          php-version: ${{ matrix.php }}
-          tools: composer
-          coverage: pcov
-          extensions: imagick
+          path: /tmp/wordpress-tests-lib
+          key: ${{ runner.os }}-wordpress-${{ matrix.wordpress }}-${{ hashFiles('bin/install-wp-tests.sh') }}
 
       - name: Install PHP dependencies
         env:
           COMPOSER_AUTH: '{"github-oauth": {"github.com": "${{secrets.PAT_FOR_GITHUB_ACTIONS}}"} }'
         run: |
           export PATH="$HOME/.composer/vendor/bin:$PATH"
-          composer install --no-interaction
+          composer install --no-interaction --prefer-dist
           echo "REPO_NAME=$(basename $(pwd))" >> $GITHUB_ENV
 
       - name: Check Standards
@@ -171,28 +132,28 @@ jobs:
       - name: Require Pressbooks
         if: inputs.requires_pressbooks == true
         run: |
-          git clone --depth=1 https://github.com/pressbooks/pressbooks.git ../pressbooks
-          cd ../pressbooks && composer install --no-dev
+          git clone --depth=1 --single-branch https://github.com/pressbooks/pressbooks.git ../pressbooks
+          cd ../pressbooks && composer install --no-dev --prefer-dist
           cd ../$REPO_NAME
 
       - name: Require Private Repo
         if: inputs.requires_private_repo != ''
         run: |
-          git clone --depth=1 https://x-access-token:${{secrets.PAT_FOR_GITHUB_ACTIONS}}@github.com/pressbooks/${{ inputs.requires_private_repo }}.git ../${{ inputs.requires_private_repo }}
-          cd ../${{ inputs.requires_private_repo }} && composer install --no-dev
+          git clone --depth=1 --single-branch https://x-access-token:${{secrets.PAT_FOR_GITHUB_ACTIONS}}@github.com/pressbooks/${{ inputs.requires_private_repo }}.git ../${{ inputs.requires_private_repo }}
+          cd ../${{ inputs.requires_private_repo }} && composer install --no-dev --prefer-dist
           cd ../$REPO_NAME
 
       - name: Install WP tests
         run: bash bin/install-wp-tests.sh wordpress_test root root 127.0.0.1 ${{ matrix.wordpress }}
 
       - name: Run PHP Tests
-        run: composer test
         if: matrix.experimental == true
+        run: composer test
 
       - name: Run PHP Tests and PCOV
-        run: composer test-coverage
         if: matrix.experimental == false && inputs.code_coverage == true
+        run: composer test-coverage
 
       - name: Upload Coverage to Codecov
-        run: bash <(curl -s https://codecov.io/bash)
         if: matrix.experimental == false && inputs.code_coverage == true
+        run: bash <(curl -s https://codecov.io/bash)

--- a/.github/workflows/pb-plugin-tests.yml
+++ b/.github/workflows/pb-plugin-tests.yml
@@ -119,7 +119,6 @@ jobs:
         image: mariadb:10.5
         env:
           MYSQL_ROOT_PASSWORD: root
-          MYSQL_DATABASE: wordpress_test
         ports:
           - 3306:3306
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3

--- a/.github/workflows/pb-plugin-tests.yml
+++ b/.github/workflows/pb-plugin-tests.yml
@@ -25,16 +25,29 @@ on:
         default: true
 
 jobs:
-  tests:
+  mysql-tests:
+    if: "!inputs.use_mariadb"
     runs-on: ubuntu-20.04
-    continue-on-error: ${{ matrix.experimental }}
+    services:
+      database:
+        image: mysql:8.0
+        env:
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_DATABASE: wordpress_test
+        ports:
+          - 3306:3306
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+
     strategy:
       fail-fast: false
       matrix:
-        php: [ 8.1, 8.2 ]
-        wordpress: [ 6.7, latest ]
-        experimental: [ false ]
         include:
+          - php: 8.1
+            wordpress: 6.7
+            experimental: false
+          - php: 8.1
+            wordpress: latest
+            experimental: false
           - php: 8.2
             wordpress: 6.7
             experimental: true
@@ -70,25 +83,92 @@ jobs:
       - name: Check Standards
         run: composer standards
 
-      - name: Remove MySQL
-        if: inputs.use_mariadb == true
-        run: sudo apt remove mysql-server-8.0 mysql-common
-
-      - name: Update apt
-        if: inputs.use_mariadb == true
-        run: sudo apt-get update
-
-      - name: Install MariaDB
-        if: inputs.use_mariadb == true
+      - name: Require Pressbooks
+        if: inputs.requires_pressbooks == true
         run: |
-          sudo apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0xF1656F24C74CD1D8
-          echo "deb http://downloads.mariadb.com/MariaDB/mariadb-10.5/repo/ubuntu focal main" | sudo tee /etc/apt/sources.list.d/mariadb.list
-          sudo apt-get update -o Dir::Etc::sourcelist="sources.list.d/mariadb.list" -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0"
-          sudo apt-get install mariadb-server-10.5 mariadb-client-10.5
-          sudo mysqladmin -p'' password 'root'
+          git clone --depth=1 https://github.com/pressbooks/pressbooks.git ../pressbooks
+          cd ../pressbooks && composer install --no-dev
+          cd ../$REPO_NAME
 
-      - name: Start Database
-        run: sudo systemctl start mysql.service && mysql --version
+      - name: Require Private Repo
+        if: inputs.requires_private_repo != ''
+        run: |
+          git clone --depth=1 https://x-access-token:${{secrets.PAT_FOR_GITHUB_ACTIONS}}@github.com/pressbooks/${{ inputs.requires_private_repo }}.git ../${{ inputs.requires_private_repo }}
+          cd ../${{ inputs.requires_private_repo }} && composer install --no-dev
+          cd ../$REPO_NAME
+
+      - name: Install WP tests
+        run: bash bin/install-wp-tests.sh wordpress_test root root 127.0.0.1 ${{ matrix.wordpress }}
+
+      - name: Run PHP Tests
+        run: composer test
+        if: matrix.experimental == true
+
+      - name: Run PHP Tests and PCOV
+        run: composer test-coverage
+        if: matrix.experimental == false && inputs.code_coverage == true
+
+      - name: Upload Coverage to Codecov
+        run: bash <(curl -s https://codecov.io/bash)
+        if: matrix.experimental == false && inputs.code_coverage == true
+
+  mariadb-tests:
+    if: inputs.use_mariadb
+    runs-on: ubuntu-20.04
+    services:
+      database:
+        image: mariadb:10.5
+        env:
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_DATABASE: wordpress_test
+        ports:
+          - 3306:3306
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - php: 8.1
+            wordpress: 6.7
+            experimental: false
+          - php: 8.1
+            wordpress: latest
+            experimental: false
+          - php: 8.2
+            wordpress: 6.7
+            experimental: true
+
+    name: Test - PHP ${{ matrix.php }} - WP ${{ matrix.wordpress }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Cache Composer packages
+        uses: actions/cache@v4
+        with:
+          path: vendor
+          key: php-${{ matrix.php }}-composer-${{ hashFiles('**/composer.lock') }}
+
+      - name: Setup PHP and extensions
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          tools: composer
+          coverage: pcov
+          extensions: imagick
+
+      - name: Install PHP dependencies
+        env:
+          COMPOSER_AUTH: '{"github-oauth": {"github.com": "${{secrets.PAT_FOR_GITHUB_ACTIONS}}"} }'
+        run: |
+          export PATH="$HOME/.composer/vendor/bin:$PATH"
+          composer install --no-interaction
+          echo "REPO_NAME=$(basename $(pwd))" >> $GITHUB_ENV
+
+      - name: Check Standards
+        run: composer standards
 
       - name: Require Pressbooks
         if: inputs.requires_pressbooks == true
@@ -105,7 +185,7 @@ jobs:
           cd ../$REPO_NAME
 
       - name: Install WP tests
-        run: bash bin/install-wp-tests.sh wordpress_test root root localhost ${{ matrix.wordpress }}
+        run: bash bin/install-wp-tests.sh wordpress_test root root 127.0.0.1 ${{ matrix.wordpress }}
 
       - name: Run PHP Tests
         run: composer test
@@ -118,20 +198,3 @@ jobs:
       - name: Upload Coverage to Codecov
         run: bash <(curl -s https://codecov.io/bash)
         if: matrix.experimental == false && inputs.code_coverage == true
-
-  coverage:
-    runs-on: ubuntu-latest
-    needs:
-      - tests
-    name: Upload coverage
-    if: needs.tests.outputs.coverage == 'true' && inputs.code_coverage == true
-    steps:
-      - uses: actions/checkout@v4
-      - name: Fetch code coverage artifact
-        uses: actions/download-artifact@v3
-        with:
-          name: code-coverage
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/pb-plugin-tests.yml
+++ b/.github/workflows/pb-plugin-tests.yml
@@ -35,7 +35,7 @@ jobs:
           MYSQL_ROOT_PASSWORD: root
         ports:
           - 3306:3306
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+        options: --health-cmd="mysqladmin ping" --health-interval=5s --health-timeout=5s --health-retries=3
 
     strategy:
       fail-fast: false

--- a/.github/workflows/pb-plugin-tests.yml
+++ b/.github/workflows/pb-plugin-tests.yml
@@ -33,7 +33,6 @@ jobs:
         image: mysql:8.0
         env:
           MYSQL_ROOT_PASSWORD: root
-          MYSQL_DATABASE: wordpress_test
         ports:
           - 3306:3306
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
@@ -52,7 +51,7 @@ jobs:
             wordpress: 6.7
             experimental: true
 
-    name: Test - PHP ${{ matrix.php }} - WP ${{ matrix.wordpress }}
+    name: Tests 🔧
 
     steps:
       - name: Checkout code

--- a/.github/workflows/pb-plugin-tests.yml
+++ b/.github/workflows/pb-plugin-tests.yml
@@ -35,7 +35,7 @@ jobs:
           MYSQL_ROOT_PASSWORD: root
         ports:
           - 3306:3306
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+        options: --health-cmd="mysqladmin ping" --health-interval=5s --health-timeout=5s --health-retries=3
 
     strategy:
       fail-fast: false
@@ -136,7 +136,7 @@ jobs:
           MYSQL_ROOT_PASSWORD: root
         ports:
           - 3306:3306
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+        options: --health-cmd="mysqladmin ping" --health-interval=5s --health-timeout=5s --health-retries=3
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
This pull request includes significant updates to the GitHub Actions workflow for plugin tests. The primary changes involve the introduction of a database service, improved caching mechanisms, and streamlined dependencies installation.

### Workflow Enhancements:

* Added a `services` section to define a database service that conditionally uses either MariaDB or MySQL based on the input parameter `use_mariadb`. This change eliminates the need for separate steps to install and configure MariaDB manually.

* Updated the matrix strategy to explicitly list the combinations of PHP and WordPress versions, including an `experimental` flag. This change improves the clarity and manageability of the test matrix.

### Caching Improvements:

* Introduced steps to cache Composer dependencies and the WordPress test suite, which should speed up the workflow by reducing the need to download these dependencies on every run.

### Dependency Management:

* Modified the installation commands for Composer dependencies to use the `--prefer-dist` option, which can result in faster installations by preferring distribution packages over source packages.

* Updated the `Require Pressbooks` and `Require Private Repo` steps to use the `--single-branch` option when cloning repositories, which reduces the amount of data fetched and speeds up the process.