### PR TITLE
fix: use ubuntu-22.04 to install php 8.1

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   release-please:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: googleapis/release-please-action@v4


### PR DESCRIPTION
Currently ubuntu-latest is installing php 8.3 this could cause issues on building artifacts

![image](https://github.com/user-attachments/assets/0c5e2fe5-28a1-4640-a838-ab72a9926d9e)
