### PR TITLE
chore: bump php 8.2

### DIFF
--- a/.github/workflows/composer-update.yml
+++ b/.github/workflows/composer-update.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.1
+          php-version: 8.2
           tools: composer
         env:
           GITHUB_TOKEN: ${{ secrets.PAT_FOR_GITHUB_ACTIONS }}

--- a/.github/workflows/pb-plugin-tests.yml
+++ b/.github/workflows/pb-plugin-tests.yml
@@ -26,7 +26,7 @@ on:
 
 jobs:
   tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     
     services:
       database:
@@ -41,13 +41,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - php: 8.1
+          - php: 8.2
             wordpress: 6.7
             experimental: false
-          - php: 8.1
+          - php: 8.2
             wordpress: latest
             experimental: true
-          - php: 8.2
+          - php: 8.3
             wordpress: 6.7
             experimental: true
 

--- a/.github/workflows/update-mo.yml
+++ b/.github/workflows/update-mo.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.2'
           tools: wp-cli/wp-cli-bundle
 
       - name: Generate .mo files from .po files

--- a/.github/workflows/update-pot.yml
+++ b/.github/workflows/update-pot.yml
@@ -53,7 +53,7 @@ jobs:
         if: contains(steps.get_pr_labels.outputs.labels, 'autorelease') == false
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.2'
           tools: wp-cli/wp-cli-bundle
 
       - name: Update POT file


### PR DESCRIPTION
This pull request includes updates to various GitHub workflow files to upgrade the PHP version and the Ubuntu version used in the CI environment. The most important changes are listed below:

### PHP Version Upgrade:
* [`.github/workflows/composer-update.yml`](diffhunk://#diff-e5830b191303ec7bf06d95fc6f3ac9c00ac29875f6d82bacb27ae7965749e880L24-R24): Updated the PHP version from 8.1 to 8.2.
* [`.github/workflows/pb-plugin-tests.yml`](diffhunk://#diff-fded742b43c62221ac53dd30e7bd372dff29f73a5f0fd4a5c2e0b94528b5de99L44-R50): Updated the PHP version from 8.1 to 8.2 and from 8.2 to 8.3 in the matrix configuration.
* [`.github/workflows/update-mo.yml`](diffhunk://#diff-3cc9ee485a4f959a98f83b38cf671c09b9261e963ea34ed75280a2f3196bd816L18-R18): Updated the PHP version from 8.1 to 8.2.
* [`.github/workflows/update-pot.yml`](diffhunk://#diff-8741980370812fcb8b10be0bc89c075d0b3c72a30463c06f17deeffd1621eed9L56-R56): Updated the PHP version from 8.1 to 8.2.

### Ubuntu Version Upgrade:
* [`.github/workflows/pb-plugin-tests.yml`](diffhunk://#diff-fded742b43c62221ac53dd30e7bd372dff29f73a5f0fd4a5c2e0b94528b5de99L29-R29): Updated the runs-on version from ubuntu-20.04 to ubuntu-22.04.