### PR TITLE
chore: update wp pb-plugin-tests.yml

### DIFF
--- a/.github/workflows/pb-plugin-tests.yml
+++ b/.github/workflows/pb-plugin-tests.yml
@@ -42,13 +42,13 @@ jobs:
       matrix:
         include:
           - php: 8.2
-            wordpress: 6.7
+            wordpress: 6.8
             experimental: false
           - php: 8.2
             wordpress: latest
             experimental: true
           - php: 8.3
-            wordpress: 6.7
+            wordpress: 6.8
             experimental: true
 
     name: PHP ${{ matrix.php }} - WP ${{ matrix.wordpress }} - ${{ (inputs.use_mariadb) && 'MariaDB' || 'MySQL' }}


### PR DESCRIPTION
This pull request updates the WordPress version used in the test matrix of the `pb-plugin-tests` GitHub Actions workflow.

* [`.github/workflows/pb-plugin-tests.yml`](diffhunk://#diff-fded742b43c62221ac53dd30e7bd372dff29f73a5f0fd4a5c2e0b94528b5de99L45-R51): Updated the WordPress version from `6.7` to `6.8` for test configurations using PHP `8.2`.