### PR TITLE
chore: update WP versions in test matrix

### DIFF
--- a/.github/workflows/pb-plugin-tests.yml
+++ b/.github/workflows/pb-plugin-tests.yml
@@ -48,7 +48,7 @@ jobs:
             wordpress: latest
             experimental: true
           - php: 8.3
-            wordpress: latest
+            wordpress: 6.8.2
             experimental: true
 
     name: PHP ${{ matrix.php }} - WP ${{ matrix.wordpress }} - ${{ (inputs.use_mariadb) && 'MariaDB' || 'MySQL' }}


### PR DESCRIPTION
This PR updates the version of WordPress used in the text matrix to 6.8.2, which is what we require in pressbooks/pressbooks and are now running in production.