### PR TITLE
chore: Upgrade PHP version and change Ubuntu runner version

### DIFF
--- a/.github/workflows/pb-plugin-tests.yml
+++ b/.github/workflows/pb-plugin-tests.yml
@@ -52,6 +52,7 @@ jobs:
             experimental: true
 
     name: PHP ${{ matrix.php }} - WP ${{ matrix.wordpress }} - ${{ (inputs.use_mariadb) && 'MariaDB' || 'MySQL' }}
+    continue-on-error: ${{ matrix.experimental == true }}
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for plugin tests to use newer versions of both the operating system and PHP, ensuring better compatibility and access to the latest features and security updates.

**CI Environment Updates:**

* Updated the workflow runner from `ubuntu-22.04` to `ubuntu-24.04` to use the latest Ubuntu LTS version.

**PHP Version Matrix Updates:**

* Updated the test matrix to use PHP 8.3 instead of 8.2 for standard and experimental builds, and advanced the experimental build to PHP 8.4.