### PR TITLE
chore: Update workflow to use Ubuntu 24.04 and PHP 8.3

### DIFF
--- a/.github/workflows/composer-update.yml
+++ b/.github/workflows/composer-update.yml
@@ -13,7 +13,7 @@ on:
         description: 'List of space seperated packages to be update. The packages can include a specific reference (ex: pressbooks/pressbooks pressbooks/pressbooks:1.0.1)'
 jobs:
   test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
         with:
@@ -21,7 +21,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.2
+          php-version: 8.3
           tools: composer
         env:
           GITHUB_TOKEN: ${{ secrets.PAT_FOR_GITHUB_ACTIONS }}


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for Composer updates to use newer versions of the operating system and PHP. These changes help keep our CI environment up to date and compatible with the latest features and security patches.

Environment updates in CI workflow:

* Updated the runner from `ubuntu-22.04` to `ubuntu-24.04` in `.github/workflows/composer-update.yml` to use the latest Ubuntu LTS release.
* Upgraded the PHP version from `8.2` to `8.3` in the same workflow file to ensure compatibility with the latest PHP features and improvements.