### PR TITLE
fix: Install OS dependencies in pb-plugin-tests.yml

### DIFF
--- a/.github/workflows/pb-plugin-tests.yml
+++ b/.github/workflows/pb-plugin-tests.yml
@@ -58,6 +58,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Install OS dependencies
+        run: |
+          sudo apt update
+          sudo apt-get install libxml2-utils ghostscript poppler-utils imagemagick subversion
+          sudo apt-get install -y libavif16 libgif7
+
       - name: Setup PHP and extensions
         uses: shivammathur/setup-php@v2
         with:


### PR DESCRIPTION
Added installation of OS dependencies for the workflow, in ubuntu 24 subversion is not installed and it's required for wp installation.