### PR TITLE
chore: Upgrade Node.js version and Ubuntu runner

### DIFF
--- a/.github/workflows/npm-build.yml
+++ b/.github/workflows/npm-build.yml
@@ -4,10 +4,10 @@ on: workflow_call
 
 jobs:
   build-and-commit:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
-        node: [ '18' ]
+        node: [ '22' ]
     name: Node ${{ matrix.node }}
 
     steps:


### PR DESCRIPTION
This pull request updates the build environment for the npm workflow to use newer versions of both Ubuntu and Node.js.

Build environment updates:

* Changed the workflow runner from `ubuntu-22.04` to `ubuntu-24.04` in `.github/workflows/npm-build.yml`, ensuring the CI uses the latest LTS Ubuntu version.
* Updated the Node.js version in the build matrix from `18` to `22` in `.github/workflows/npm-build.yml`, aligning with the latest supported Node.js release.