### PR TITLE
Enable npm caching in GitHub Actions workflow

### DIFF
--- a/.github/workflows/npm-build.yml
+++ b/.github/workflows/npm-build.yml
@@ -20,12 +20,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node }}
-
-      - name: Cache node modules
-        uses: actions/cache@v5
-        with:
-          path: node_modules
-          key: node-${{ runner.OS }}-build-${{ hashFiles('**/package-lock.json') }}
+          cache: 'npm'
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
This pull request updates the Node.js dependency caching strategy in the GitHub Actions workflow for building npm projects. The main change is the removal of the explicit `actions/cache` step in favor of using the built-in `cache: 'npm'` option with `actions/setup-node`.

Workflow improvements:

* [`.github/workflows/npm-build.yml`](diffhunk://#diff-e9090522615b70457c65d067e6be85c42aa2a2f3d911fa0b5aa215696452ff70L23-R23): Replaced the manual `actions/cache` step for caching `node_modules` with the `cache: 'npm'` option in the `actions/setup-node` step, simplifying configuration and leveraging native npm caching support.