### PR TITLE
feat: inject tests token

### DIFF
--- a/.github/workflows/pb-plugin-tests.yml
+++ b/.github/workflows/pb-plugin-tests.yml
@@ -134,10 +134,14 @@ jobs:
 
       - name: Run PHP Tests
         if: matrix.experimental == true
+        env:
+          X_PB_CI_TOKEN: ${{ secrets.X_PB_CI_TOKEN }}
         run: composer test
 
       - name: Run PHP Tests and PCOV
         if: matrix.experimental == false && inputs.code_coverage == true
+        env:
+          X_PB_CI_TOKEN: ${{ secrets.X_PB_CI_TOKEN }}
         run: composer test-coverage
 
       - name: Upload Coverage to Codecov


### PR DESCRIPTION
This pull request makes a minor update to the GitHub Actions workflow for plugin tests, ensuring that the `X_PB_CI_TOKEN` environment variable is available during PHP test runs. This change helps provide necessary credentials or tokens during CI.

- CI/CD workflow improvement:
  * [`.github/workflows/pb-plugin-tests.yml`](diffhunk://#diff-fded742b43c62221ac53dd30e7bd372dff29f73a5f0fd4a5c2e0b94528b5de99R137-R144): Added the `X_PB_CI_TOKEN` environment variable to the environments for both regular and coverage PHP test jobs, ensuring the token is available during test execution.